### PR TITLE
Support pre-submit Spam checking

### DIFF
--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -576,7 +576,7 @@ $message_parser->set_plupload($plupload);
 if (isset($post_data['post_text']))
 {
 	$message_parser->message = &$post_data['post_text'];
-	unset($post_data['post_text']);
+//	unset($post_data['post_text']);
 }
 
 // Set some default variables


### PR DESCRIPTION
Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-12345

Why is the message text being removed? The subsequent "core.posting_modify_submission_errors" then has no way to check the message for spam.
The next events, e.g. "core.posting_modify_submit_post_before" OTOH *have* this message from "'message' => $message_parser->message,", but they are not allowed to notify an error condition. So it's a catch 22.
Best solution would be to allow "core.posting_modify_submission_errors" to check the message.